### PR TITLE
Update triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,9 +16,6 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Run issue labeler
         uses: github/issue-labeler@v3.4
         with:
@@ -36,9 +33,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Run PR labeler
         uses: actions/labeler@v6
         with:
@@ -49,12 +43,10 @@ jobs:
     if: github.event.action == 'opened' || github.event.action == 'edited'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Run request info
         uses: tomdewildt/request-info@v1
         with:
@@ -67,9 +59,6 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Run first interaction
         uses: tomdewildt/first-interaction@v1
         with:


### PR DESCRIPTION
**What type of PR is this?**
- [x] Refactor

**What this PR does / why we need it**:

Remove unnecessary `actions/checkout` from all triage workflow jobs and add `contents: read` permission to jobs that read repo files via the GitHub API. Fixes triage workflow on private repos.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```